### PR TITLE
fix: prevent old questions briefly showing during reinitializaion

### DIFF
--- a/rygstatus.client/src/ryg_status_form.tsx
+++ b/rygstatus.client/src/ryg_status_form.tsx
@@ -185,12 +185,20 @@ function BoBrkRwaDetection() {
         }
     };
 
-    const handleStartOver = () => {
+    const handleStartOver = async () => {
+        // Set loading to true first to show loading state
+        setLoading(true);
+        // Clear previous data
+        setQuestions([]);
+        
+        // Wait for fetch to complete before changing view
+        await fetchQuestions();
+        
+        // Then update the UI state
         setIsSubmitted(false);
         setStatus(null);
         setCurrentQuestionIndex(0);
         setShowSelectionWarning(false);
-        fetchQuestions();
     };
 
     const LoadingComponent = () => (


### PR DESCRIPTION
Refactor handleStartOver to set loading state immediately and clear previous questions before fetching new ones. This eliminates the flickering effect where users would briefly see the previous questions when clicking REINITIALIZE.